### PR TITLE
Scope improvements: scrub private repo names, revert dependency declaration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,9 @@ Deployment target only. Source files live in their origin repos (e.g. kary-denta
 
 **Read `TODO.md` at session start for current active tasks.**
 
+## Dependencies
+karyandrew/second-brain
+
 ## Deployment
 - **Source:** Deploy from branch `main`, root (`/`)
 - Changes pushed to `main` auto-deploy via GitHub Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Repo:** `karyandrew/pages` | **Default branch:** `main`
 
-Deployment target only. Source files live in their origin repos (e.g. kary-dental). This repo hosts copies for GitHub Pages serving at `karyandrew.github.io/pages`.
+Deployment target only. Source files live in their origin repos. This repo hosts copies for GitHub Pages serving at `karyandrew.github.io/pages`.
 
 **Read `TODO.md` at session start for current active tasks.**
 
@@ -24,12 +24,12 @@ If the work should NOT be merged (dead end, abandoned), say so explicitly before
 
 ## git-graph.html
 
-Static Mermaid gitGraph for kary-dental. **Always update the date in the `<p>` tag** whenever the graph content changes — it's the only freshness signal users see.
+Static Mermaid gitGraph. **Always update the date in the `<p>` tag** whenever the graph content changes — it's the only freshness signal users see.
 
 **Constraints learned the hard way:**
-- kary-dental is a private repo — client-side GitHub API fetch returns 404 without auth. Dynamic fetching requires a server-side step (GitHub Actions). Don't attempt it client-side.
+- Origin repos may be private — client-side GitHub API fetch returns 404 without auth. Dynamic fetching requires a server-side step (GitHub Actions). Don't attempt it client-side.
 - Mermaid v11 rejects `/` in branch names. Use `-` instead (`claude-feature-x`, not `claude/feature-x`).
 - Commit id strings: alphanumeric, spaces, hyphens only. No `:` `/` `.` `()` and do not use reserved words (`merge`, `commit`, `branch`, `checkout`) as id values.
 - Merge commit ids: use `"3way"` / `"3way-2"` etc. for three-way merges, `"ff"` for fast-forward.
 
-**To update the graph:** pull the commit log via MCP tools (`mcp__github__list_commits` on kary-dental main), reconstruct the branch topology from merge commit messages, rewrite the Mermaid block, update the date.
+**To update the graph:** pull the commit log from the origin repo (via `mcp__github__list_commits`), reconstruct the branch topology from merge commit messages, rewrite the Mermaid block, update the date.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,6 @@ Deployment target only. Source files live in their origin repos (e.g. kary-denta
 
 **Read `TODO.md` at session start for current active tasks.**
 
-## Dependencies
-karyandrew/second-brain
-
 ## Deployment
 - **Source:** Deploy from branch `main`, root (`/`)
 - Changes pushed to `main` auto-deploy via GitHub Pages

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## git-graph.html
 
-- [ ] Update git-graph.html when kary-dental branch topology changes
+- [ ] Regenerate git-graph.html **on request only** (not automatic). Trigger: Andrew asks for an update after a notable kary-dental branch-topology change.
 
 ## kd-tax-strategy.md
 


### PR DESCRIPTION
## Summary
- Scrub karyandrew/* private repo names from public CLAUDE.md
- Revert second-brain dependency declaration; pages is a deployment wall, not a consumer of shared rules

## Commits
1. `ecc31e1` Declare second-brain dependency (reverted below)
2. `1972c68` Revert Dependencies declaration on pages
3. `4753e17` Scrub private repo names from pages CLAUDE.md
