### PR TITLE
Add SessionStart hook to fetch second-brain rules

### DIFF
--- a/.claude/hooks/fetch-second-brain-rules.sh
+++ b/.claude/hooks/fetch-second-brain-rules.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SessionStart hook: clone karyandrew/second-brain into .claude/.cache/ so
+# agents in remote (web) sandboxes can read canonical rules as local files.
+# Needs GITHUB_TOKEN (or GH_TOKEN) in the sandbox env — soft-fails without it
+# so the session still starts.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+CACHE_DIR="$PROJECT_DIR/.claude/.cache/second-brain"
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+
+if [ -z "$TOKEN" ]; then
+  echo "fetch-second-brain-rules: no GITHUB_TOKEN in env; skipping" >&2
+  exit 0
+fi
+
+# URL-embedded auth works for both PATs (ghp_, github_pat_) and OAuth (gho_).
+# http.extraheader rejects gho_ tokens, so we pay the cost of the token landing
+# in the cache's .git/config — acceptable because .claude/.cache is gitignored
+# and only exists in the ephemeral sandbox.
+AUTH_URL="https://x-access-token:${TOKEN}@github.com/karyandrew/second-brain.git"
+
+mkdir -p "$(dirname "$CACHE_DIR")"
+
+if [ -d "$CACHE_DIR/.git" ]; then
+  # Re-set remote URL so a rotated token in env takes effect.
+  git -C "$CACHE_DIR" remote set-url origin "$AUTH_URL"
+  if ! git -C "$CACHE_DIR" fetch --depth 1 origin main >/dev/null 2>&1; then
+    echo "fetch-second-brain-rules: fetch failed; using stale cache" >&2
+    exit 0
+  fi
+  git -C "$CACHE_DIR" reset --hard origin/main >/dev/null
+else
+  if ! git clone --depth 1 "$AUTH_URL" "$CACHE_DIR" >/dev/null 2>&1; then
+    echo "fetch-second-brain-rules: clone failed" >&2
+    exit 0
+  fi
+fi
+
+echo "fetch-second-brain-rules: second-brain refreshed at $CACHE_DIR" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,14 @@
-{}
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/fetch-second-brain-rules.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Claude Code sandbox cache
+.claude/.cache/


### PR DESCRIPTION
## Summary

Adds `.claude/hooks/fetch-second-brain-rules.sh` — a SessionStart hook that clones `karyandrew/second-brain` into `.claude/.cache/second-brain/` when a **remote (web) session** starts, so agents in the web sandbox can read canonical rules as local files.

Addresses item #1 in `second-brain/todos/readiness-audit-followups.md`. Part of a 5-repo port (kd, spa, 3d-printing, pages, fiction).

## Behavior

| Condition | Outcome |
|---|---|
| Local session (`CLAUDE_CODE_REMOTE` ≠ `true`) | no-op, `exit 0` |
| Remote session, no `GITHUB_TOKEN`/`GH_TOKEN` | log + `exit 0` (session continues) |
| Remote session, token present, cold clone | `git clone --depth 1` into cache dir |
| Remote session, token present, cache exists | re-set remote URL (for token rotation), fetch, hard reset to `origin/main` |
| Remote session, token present, network fails | log "using stale cache" + `exit 0` |

All failure paths exit 0 so a transient issue never blocks session start.

## Auth note

Uses URL-embedded token (`https://x-access-token:${TOKEN}@github.com/...`) because `http.extraheader` rejects `gho_` OAuth tokens. Token lands in the cache's `.git/config` — acceptable because `.claude/.cache/` is gitignored and only exists in the ephemeral sandbox.

## Gating

Needs `GITHUB_TOKEN` (or `GH_TOKEN`) injected into the web sandbox env via settings — that's a separate follow-up, not part of this PR.

## Test plan

- [x] Local dry-run (no-op, exits 0)
- [x] Cold clone with real token
- [x] Warm fetch with real token
- [x] Missing-token soft-fail
- [ ] End-to-end: launch a web session against this repo once `GITHUB_TOKEN` is wired into sandbox env, confirm `.claude/.cache/second-brain/rules/` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)